### PR TITLE
accept Null createdAt beacause createdAt and prductCreatedAt

### DIFF
--- a/lib/_core/constants/http.dart
+++ b/lib/_core/constants/http.dart
@@ -4,7 +4,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 // http 통신
 final dio = Dio(
   BaseOptions(
-    baseUrl: "http://192.168.0.24:8080", // 내 IP 입력
+    baseUrl: "http://192.168.0.17:8080", // 내 IP 입력
     contentType: "application/json; charset=utf-8",
   ),
 );

--- a/lib/data/model/product.dart
+++ b/lib/data/model/product.dart
@@ -7,7 +7,7 @@ class Product {
   String productName;
   String? productDescription;
   int productPrice;
-  String productCreatedAt;
+  String? productCreatedAt;
   User user;
   List<ProductPic> productPics;
   int? productComment;
@@ -20,7 +20,7 @@ class Product {
     required this.productPrice,
     required this.productPics,
     required this.user,
-    required this.productCreatedAt,
+    this.productCreatedAt,
     this.productComment,
     this.productLike,
   });


### PR DESCRIPTION
[이정완]

봉주나, 통신쪽에 잔잔한 에러있어서 하나 잡았어.

product Detail 페이지에서는 응답해주는 DTO 의 시간 필드값이 createdAt인데.
product List 페이지에서는 응답해주는 DTO 의 시간 필드값이 productCretaedAt이라서 필드값이 달라서 우리쪽은 바인딩이 안되서
바인딩이 안되는것은 null을 허용시켜서 처리하니까 가능하드라.


############## 정리  ############### 
서버의 응답값
productDetail 페이지 DTO 필드값 createdAt
productList 페이지 DTO 필드값 productCreatedAt  

프론트측의 모델 Product가 담을수 있는 시간 필드값
productCreatedAt 
[디테일 페이지에만 시간이 필요하기때문에 널값을 허용해서 처리를 함]

